### PR TITLE
Update gulp-jshint to 1.9.2

### DIFF
--- a/pbserver/package.json
+++ b/pbserver/package.json
@@ -51,7 +51,7 @@
   "devDependencies": {
     "gulp-util": "~2.2.14",
     "gulp": "~3.8.7",
-    "gulp-jshint": "~1.8.4",
+    "gulp-jshint": "~1.9.2",
     "gulp-jscs": "~1.1.2",
     "gulp-replace": "~0.5.1",
     "jshint-stylish": "~0.1.5"


### PR DESCRIPTION
Build errors from dependencies fixed in new version
