### PR TITLE
--production flag for npm installation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ This will set your command line's location to Pokémon Showdown's folder. You'll
 
 To install dependencies, run the command:
 
-    npm install
+    npm install --production
 
 Copy `config/config-example.js` into `config/config.js`, and edit as you please.
 

--- a/app.js
+++ b/app.js
@@ -57,10 +57,10 @@ function runNpm(command) {
 try {
 	require('sugar');
 } catch (e) {
-	runNpm('install');
+	runNpm('install --production');
 }
 if (!Object.select) {
-	runNpm('update');
+	runNpm('update --production');
 }
 
 // Make sure config.js exists, and copy it over from config-example.js


### PR DESCRIPTION
This doesn't pull dev dependencies, not forcing people to install git in order to install `gulp-jshint`.
